### PR TITLE
Fix for Epic productSlug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-free-games-notifier",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-free-games-notifier",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A Discord bot that will notify when free games on Steam or Epic Games come out.",
   "main": "./src/app.js",
   "scripts": {

--- a/src/classes/providers/EpicGamesProvider.js
+++ b/src/classes/providers/EpicGamesProvider.js
@@ -33,7 +33,7 @@ class EpicGamesProvider extends AbstractProvider {
           if (game.promotions && game.promotions.promotionalOffers &&
               game.promotions.promotionalOffers.length > 0 &&
               game.price.totalPrice.discountPrice === 0) {
-            const pageSlugg = game.offerMappings.find(pageSlug => pageSlug).pageSlug
+            const pageSlugg = game.catalogNs.mappings.find(pageSlug => pageSlug).pageSlug
             let url = `https://epicgames.com/store/product/${pageSlugg}`;
 
             if (!url.endsWith('/home')) {

--- a/src/classes/providers/EpicGamesProvider.js
+++ b/src/classes/providers/EpicGamesProvider.js
@@ -33,13 +33,14 @@ class EpicGamesProvider extends AbstractProvider {
           if (game.promotions && game.promotions.promotionalOffers &&
               game.promotions.promotionalOffers.length > 0 &&
               game.price.totalPrice.discountPrice === 0) {
-            let url = `https://epicgames.com/store/product/${game.productSlug}`;
+            const pageSlugg = game.offerMappings.find(pageSlug => pageSlug).pageSlug
+            let url = `https://epicgames.com/store/product/${pageSlugg}`;
 
             if (!url.endsWith('/home')) {
               url += '/home';
             }
 
-            offers.push(AbstractProvider.createOffer(this.name, game.title, url, game.productSlug));
+            offers.push(AbstractProvider.createOffer(this.name, game.title, url, pageSlugg));
           }
           return offers;
         }, []);


### PR DESCRIPTION
### :pencil: Checklist

Make sure that your PR fulfills these requirements:

- [x] Tests have been added for this feature.
- [x] All tests pass on your local machine. // Seems to work, but Epic may change stuff later.
- [x] Code has been linted with the proper rules.

### :page_facing_up: Description

Instead of getting productSlug, I'm getting a pageSlug from catalogNs > mappings. Should always go to product page.

### :pushpin: Does this PR address any issue?

#19
